### PR TITLE
update setup url with current repo location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     maintainer='Ashley Felton',
     maintainer_email='asi@dpaw.wa.gov.au',
     license='Apache License, Version 2.0',
-    url='https://bitbucket.org/dpaw/webtemplate-dpaw',
+    url='https://github.com/parksandwildlife/webtemplate-dpaw',
     description='Base HTML templates for DPaW Django projects',
     long_description=README,
     keywords=['django', 'html', 'template', 'dpaw'],


### PR DESCRIPTION
s/bitbucket.org\/dpaw\/webtemplate-dpaw/github.com\/parksandwildlife\/webtemplate-dpaw/

BitBucket does provide a manual re-direct link, so you can still click your way from PyPI to the code the way it is now, but I figured you'd want a reminder to update it anyway so...

Thanks for sharing your code!  